### PR TITLE
remove "link to object" button from record if filename field is empty

### DIFF
--- a/_includes/js/item-js.html
+++ b/_includes/js/item-js.html
@@ -14,6 +14,9 @@ var cb_items = [
 
 /* function to find links to objects from filename field */ 
 function findFileLink(record) {
+    if (!record.filename) {
+        return "";
+    }
     var fileLink = record.filename.includes('/') ? record.filename : "{{ '/objects/' | relative_url }}" + record.filename;
     return fileLink;
 }


### PR DESCRIPTION
Not all metadata records with format "record" necessarily have values for filename. This removes the default link to filename if the value is blank.